### PR TITLE
Add X-Accel-Buffering: no to disable buffer

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -50,6 +50,8 @@ http {
 
   server {
     listen           9080 default_server;
+    add_header       X-Accel-Buffering no;
+
     #listen          9443 ssl;
     #ssl_certificate     /usr/local/nginx/ssl/server.crt;
     #ssl_certificate_key /usr/local/nginx/ssl/server.key;


### PR DESCRIPTION
This PR adds `X-Accel-Buffering` header to `no`, to disable buffer in connection through proxy.